### PR TITLE
models.de-pos-ud: init at 20190821

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,12 @@ rec {
     cudnn = cudnn_cudatoolkit_10_0;
   };
 
+  models = pkgs.recurseIntoAttrs (
+    pkgs.callPackage ./pkgs/models {
+      inherit sticker;
+    }
+  );
+
   sticker = pkgs.callPackage ./pkgs/sticker {
     libtensorflow = libtensorflow_1_14_0;
   };

--- a/pkgs/models/default.nix
+++ b/pkgs/models/default.nix
@@ -1,0 +1,30 @@
+{ lib, recurseIntoAttrs, stdenvNoCC, fetchurl, makeWrapper, sticker }:
+
+let
+  stickerModel = import ./model.nix;
+
+  # Embeddings fetcher, uses the sticker-models repository.
+  fetchEmbeddings = { name, sha256 }: {
+    embeds = fetchurl {
+      inherit sha256;
+      url = "https://github.com/stickeritis/sticker-models/releases/download/${name}/${name}.fifu";
+    };
+
+    filename = "${name}.fifu";
+  };
+
+  deWordEmbeds = fetchEmbeddings {
+    name = "de-structgram-20190426-opq";
+    sha256 = "0b75bpsrfxh173ssa91pql3xmvd7x9f2qwc6rv27jj6pxlhayfql";
+  };
+in lib.mapAttrs (_: value: recurseIntoAttrs value) {
+  de-pos-ud = stickerModel {
+    inherit stdenvNoCC fetchurl makeWrapper sticker;
+
+    modelName = "de-pos-ud";
+    version = "20190821";
+    sha256 = "163himdn8l1ds6znf1girx0hbplbc8i9z9lmqdwvxsj9d9338svv";
+
+    wordEmbeds = deWordEmbeds;
+  };
+}

--- a/pkgs/models/model.nix
+++ b/pkgs/models/model.nix
@@ -1,0 +1,85 @@
+{ stdenvNoCC
+, fetchurl
+, makeWrapper
+
+, sticker
+
+# Word and tag embeddings as an attrset, containing the attributes:
+#
+# - embeds: Embedding file fixed-output derivation.
+# - filename: Embedding file name in the model's sticker.conf
+, wordEmbeds
+, tagEmbeds ? null
+
+# Short name of the model. E.g.: de-pos-ud.
+, modelName
+
+# Version of the model, typically a date. E.g.: 20190821
+, version
+
+, sha256
+}:
+
+rec {
+  model = stdenvNoCC.mkDerivation rec {
+    inherit version;
+
+    pname = "sticker-model-${modelName}";
+
+    src = fetchurl {
+      inherit sha256;
+
+      url = let
+        fullName = "${modelName}-${version}";
+        in "https://github.com/stickeritis/sticker-models/releases/download/${fullName}/${fullName}.tar.gz";
+    };
+
+    preConfigure = ''
+      substituteInPlace sticker.conf \
+        --replace "${wordEmbeds.filename}" \
+      "${wordEmbeds.embeds}"
+    '' + stdenvNoCC.lib.optionalString (tagEmbeds != null) ''
+      substituteInPlace sticker.conf \
+        --replace "${tagEmbeds.filename}" \
+      "${tagEmbeds.embeds}"
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share/sticker/models/${modelName}
+      install -m 0644 *.conf *.graph *.labels *.shapes epoch-* $out/share/sticker/models/${modelName}
+    '';
+
+    meta = with stdenvNoCC.lib; {
+      homepage = https://github.com/danieldk/sticker/;
+      description = "Sticker ${modelName} model";
+      license = licenses.unfreeRedistributable;
+      maintainers = with maintainers; [ danieldk ];
+      platforms = platforms.unix;
+    };
+  };
+
+  wrapper = stdenvNoCC.mkDerivation rec {
+    inherit version;
+
+    pname = "sticker-${modelName}";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    unpackPhase = "true";
+
+    installPhase = ''
+      makeWrapper ${sticker}/bin/sticker-tag $out/bin/sticker-tag-${modelName} \
+        --add-flags "${model}/share/sticker/models/${modelName}/sticker.conf"
+      makeWrapper ${sticker}/bin/sticker-server $out/bin/sticker-server-${modelName} \
+        --add-flags "${model}/share/sticker/models/${modelName}/sticker.conf"
+    '';
+
+    meta = with stdenvNoCC.lib; {
+      homepage = https://github.com/danieldk/sticker/;
+      description = "Sticker ${modelName} model wrapper";
+      license = licenses.unfreeRedistributable;
+      maintainers = with maintainers; [ danieldk ];
+      platforms = platforms.unix;
+    };
+  };
+}


### PR DESCRIPTION
This also introduces common functions for defining embeddings and
models.

---

I am migrating the sticker model derivations from my [personal package set](https://git.sr.ht/~danieldk/nix-packages) to this organization repository. While doing this, I have also cleaned up and improved the derivations a little. The derivations in my package set have been used to generate the [Docker images](https://hub.docker.com/r/danieldk/sticker) used by e.g. CLARIN -- once you have the Nix derivations generating Docker images is trivial.

I understand that this PR is difficult to review without experience with Nix or functional programming, but I would appreciate a quick look to see if anything sticks out. This change introduces:

* The attribute `models`, which will hold sticker models;
* for each model `models.<modelname>` the derivations `models.<modelname>.model` and `model.<modelname>.wrapper` are generated. The first derivation is just the bare model. The second derivation provides wrapper scripts of the form `sticker-server-<modelname>` and `sticker-tag-<modelname>` that call sticker with the respective model;
* the German UD part-of-speech tagging model (`models.de-pos-ud`), version 20190821.