### PR TITLE
dockerImages: generate from model set

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,10 @@ rec {
   modules = import ./modules;
   overlays = import ./overlays;
 
+  dockerImages = pkgs.callPackage ./docker-images {
+    inherit models;
+  };
+
   # Pin Tensorflow to our preferred version.
   libtensorflow_1_14_0 = with pkgs; callPackage ./pkgs/libtensorflow {
     inherit (linuxPackages) nvidia_x11;

--- a/docker-images/default.nix
+++ b/docker-images/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, dockerTools
+
+  # Sticker model set.
+, models
+
+  # Docker image name.
+, imageName ? "danieldk/sticker"
+
+  # The maximum number of layers in a docker image.
+, maxLayers ? 100
+}:
+
+let
+  stickerImage = tagPrefix: version: wrapper:
+    dockerTools.buildLayeredImage {
+      inherit maxLayers;
+
+      name = imageName;
+      tag = "${tagPrefix}-${version}";
+      contents = wrapper;
+    };
+  isModel = _: v: builtins.isAttrs v && v ? "wrapper" && v ? "model";
+in
+builtins.mapAttrs (n: v: stickerImage n v.wrapper.version v.wrapper)
+  (lib.filterAttrs isModel models)


### PR DESCRIPTION
This change adds a top-level `dockerImages` attribute. It maps to an
attribute set defining a (layered) Docker image for each model of the
top-level `models` attribute.