### PR TITLE
de-deps-ud-small: init at 20190923

### DIFF
--- a/pkgs/models/default.nix
+++ b/pkgs/models/default.nix
@@ -13,11 +13,26 @@ let
     filename = "${name}.fifu";
   };
 
+  deUdSttsTagEmbeds = fetchEmbeddings {
+    name = "de-structgram-tags-ud-20190629";
+    sha256 = "1dglh4y04v9nagxa7rjlh4381652gmv53v64asin09x69wa3hi2j";
+  };
   deWordEmbeds = fetchEmbeddings {
     name = "de-structgram-20190426-opq";
     sha256 = "0b75bpsrfxh173ssa91pql3xmvd7x9f2qwc6rv27jj6pxlhayfql";
   };
 in lib.mapAttrs (_: value: recurseIntoAttrs value) {
+  de-deps-ud-small = stickerModel {
+    inherit stdenvNoCC fetchurl makeWrapper sticker;
+
+    modelName = "de-deps-ud-small";
+    version = "20190923";
+    sha256 = "1q405xmdlvwndf8y8pij89qjkd5i43x35vwfpijzq729s7ry3mpc";
+
+    wordEmbeds = deWordEmbeds;
+    tagEmbeds = deUdSttsTagEmbeds;
+  };
+
   de-pos-ud = stickerModel {
     inherit stdenvNoCC fetchurl makeWrapper sticker;
 


### PR DESCRIPTION
This is a dependency parsing model without pretraining. Especially fit for machines with less RAM or less powerful CPU.