### PR TITLE
pipelines: add the createPipeline function + examples

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,12 @@ rec {
     }
   );
 
+  pipelines = pkgs.recurseIntoAttrs (
+    pkgs.callPackage ./pkgs/pipelines {
+      inherit models sticker;
+    }
+  );
+
   python3Packages = pkgs.recurseIntoAttrs (
     pkgs.python3Packages.callPackage ./pkgs/python-modules {}
   );

--- a/pkgs/models/model.nix
+++ b/pkgs/models/model.nix
@@ -21,6 +21,8 @@
 }:
 
 rec {
+  inherit modelName;
+
   model = stdenvNoCC.mkDerivation rec {
     inherit version;
 

--- a/pkgs/pipelines/default.nix
+++ b/pkgs/pipelines/default.nix
@@ -1,0 +1,28 @@
+{ callPackage, sticker, models }:
+
+rec {
+  createPipeline = callPackage ./pipeline.nix {
+    inherit sticker;
+  };
+
+  de-ud = createPipeline {
+    name = "de-ud";
+    version = "20191002";
+    models = with models; [
+      de-pos-ud
+      de-topo-ud-small
+      de-deps-ud-large
+      de-ner-ud-small
+    ];
+  };
+
+  nl-ud = createPipeline {
+    name = "nl-ud";
+    version = "20191003";
+    models = with models; [
+      nl-pos-ud
+      nl-deps-ud-large
+      nl-ner-ud-small
+    ];
+  };
+}


### PR DESCRIPTION
The `createPipeline` function can be used to create derivations with
pipelines of sticker models. For instance, the following invocation
creates a tagging/parsing pipeline for Dutch:

```nix
nl-ud = createPipeline {
  name = "nl-ud";
  version = "20191003";
  models = with models; [
    nl-pos-ud
    nl-deps-ud-large
  ];
};
```

The output of the derivation contains the `sticker-tag-pipeline-nl-ud`
and `sticker-server-pipeline-nl-ud` utitilities. These wrap the
corresponding sticker programs, adding the models as arguments.