### PR TITLE
Pin the package set to a specific version of nixpkgs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ jobs:
       matrix:
         channel:
           - "https://nixos.org/channels/nixos-19.09"
-          - "https://nixos.org/channels/nixos-unstable"
-          - "https://nixos.org/channels/nixpkgs-unstable"
     steps:
     - uses: actions/checkout@v1
     - uses: cachix/install-nix-action@v3

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (import ./nix/sources.nix).nixpkgs {} }:
 
 let
   sources = import ./nix/sources.nix;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/danieldk/nix-packages/archive/55e62acf6a810709b6e456668aa03cfe2a042394.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs": {
+        "branch": "release-19.09",
+        "description": "Nix Packages collection",
+        "homepage": null,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6d9a4a615ee2706047c2cec3acc61d2cfbffdb0b",
+        "sha256": "1zgwp31nqh7glh7l2i0n5vic5jv1683l6lvc7r7wdmkbsbkmig1p",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d9a4a615ee2706047c2cec3acc61d2cfbffdb0b.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This choice is not made lightly. This is not a general package set,
but a package set specifically provided to build sticker. The benefit
of pinning nixpkgs is twofold:

1. We are providing a version of the sticker set that we have tested.
2. Building a derivation from a particular revision of the package set
   becomes fully reproducible.

(There is still one wrinkle: the nightly Rust compiler for the Python
packages.)