### PR TITLE
libtensorflow: init at 1.15.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ in rec {
   overlays = import ./overlays;
 
   # Pin Tensorflow to our preferred version.
-  libtensorflow_1_14_0 = with pkgs; callPackage ./pkgs/libtensorflow {
+  libtensorflow = with pkgs; callPackage ./pkgs/libtensorflow {
     inherit (linuxPackages) nvidia_x11;
     cudatoolkit = cudatoolkit_10_0;
     cudnn = cudnn_cudatoolkit_10_0;
@@ -21,7 +21,7 @@ in rec {
   );
 
   sticker = pkgs.callPackage ./pkgs/sticker {
-    libtensorflow = libtensorflow_1_14_0;
+    inherit libtensorflow;
   };
 
   sticker_models = pkgs.recurseIntoAttrs (

--- a/pkgs/libtensorflow/default.nix
+++ b/pkgs/libtensorflow/default.nix
@@ -31,19 +31,15 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "libtensorflow";
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchurl {
     url = "https://blob.danieldk.eu/${pname}/${pname}-${tfType}-${system}-avx-fma-${version}.tar.gz";
     sha256 =
       if system == "linux-x86_64" then
         if cudaSupport
-        then "0ygq7ddjd4ahzkjgfjy01zxkczkxy6n5jp3bb75z02nlx87pw3d0"
-        else "1xcgkls4hrxgdhnap4ngnda3l8a0b6fp41xp2xpmmm51rbgfzs90"
-      else if system == "darwin-x86_64" then
-        if cudaSupport
-        then unavailable
-        else "120lr69f684lfcv5chivkq0xxaf0jjp0i7ms542mb971iji95cmv"
+        then "1gkx76lc9zi8xcqxm1n2mmf44bb7nc59h9k6szlyas735d500q7f"
+        else "0yrm9jkb31a8y5brlmh0z2bwkh0z62x2yr4b8vwzlh4xicq3cll2"
       else unavailable;
   };
 


### PR DESCRIPTION
- Replace the libtensorflow_1_14_0 attribute.
- Use libtensorflow for sticker.
- Darwin support is still missing :(.