### PR TITLE
sticker_models.vmImages: add support for qcow model VM images

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,10 @@
-{ pkgs ? import (import ./nix/sources.nix).nixpkgs {} }:
+{ pkgs ? import (import nix/sources.nix).nixpkgs {} }:
 
 let
-  sources = import ./nix/sources.nix;
+  sources = import nix/sources.nix;
+  generateImages = import nixos/generate-images.nix {
+    inherit (sources) nixpkgs nixos-generators;
+  };
 in rec {
   # The `lib`, `modules`, and `overlay` names are special
   lib = import ./lib { inherit pkgs; };
@@ -29,7 +32,7 @@ in rec {
 
   sticker_models = pkgs.recurseIntoAttrs (
     pkgs.callPackage ./pkgs/sticker_models {
-      inherit sticker;
+      inherit generateImages sticker;
     }
   );
 
@@ -49,6 +52,7 @@ in rec {
 
   sticker2_models = pkgs.recurseIntoAttrs (
     pkgs.callPackage ./pkgs/sticker2_models {
+      inherit generateImages;
       sticker2 = sticker2.override { withHdf5 = false; };
     }
   );

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "nixos-generators": {
+        "branch": "master",
+        "description": "Collection of image builders [maintainer=@Lassulus]",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "2094f0de8a7ad33f00c95775dc69ebdd6c760db5",
+        "sha256": "1bw9r7gcakpwxjmniwcfvfq3f3vryf1r22ssd30077ila35vj1h0",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/nixos-generators/archive/2094f0de8a7ad33f00c95775dc69ebdd6c760db5.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-unstable",
         "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",

--- a/nixos/generate-images.nix
+++ b/nixos/generate-images.nix
@@ -1,0 +1,20 @@
+{ nixpkgs, nixos-generators }:
+
+configuration:
+
+let
+  # Get the image attribute of the VM configuration.
+  generate = format-config: let
+    self = generate' format-config;
+  in self.config.system.build.${self.config.formatAttr};
+
+  # Generate a VM system configuration.
+  generate' = format-config: import "${nixos-generators}/nixos-generate.nix" {
+    inherit configuration format-config nixpkgs;
+  };
+
+  # QEMU qcow configuration.
+  qcowConfiguration = import "${nixos-generators}/formats/qcow.nix";
+in {
+  qcow = generate qcowConfiguration;
+}

--- a/nixos/vm-configuration.nix
+++ b/nixos/vm-configuration.nix
@@ -1,0 +1,26 @@
+{ runCommand }:
+
+{ pkgs, ... } :{
+
+  networking.firewall.allowedTCPPorts = [ 4000 ];
+
+  services.openssh = {
+    enable = true;
+    permitRootLogin = "yes";
+  };
+
+  systemd.services.sticker = {
+    enable = true;
+    description = "sticker service";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network.target" ];
+    serviceConfig = {
+      Restart = "on-abort";
+      DynamicUser = true;
+      ExecStart = runCommand;
+    };
+  };
+
+  # Set the default root password to 'stickeritis'. Users should change this!
+  users.users.root.hashedPassword = "$6$HYsNSILtiizom$YCyX7Hu9mSxR4z/MoTxaMyN8RORMgJv.yBZqXrnJzi/WxzZaszElc33.lRjClqkSGNeARzlmtEVQCH6Q2lpQZ1";
+}

--- a/pkgs/sticker2_models/default.nix
+++ b/pkgs/sticker2_models/default.nix
@@ -1,8 +1,16 @@
-{ lib, recurseIntoAttrs, stdenvNoCC, fetchurl, dockerTools, makeWrapper, sticker2 }:
+{ lib
+, recurseIntoAttrs
+, stdenvNoCC
+, fetchurl
+, dockerTools
+, generateImages
+, makeWrapper
+, sticker2
+}:
 
 let
   stickerModel = import ./model.nix {
-    inherit lib stdenvNoCC fetchurl dockerTools makeWrapper sticker2;
+    inherit lib stdenvNoCC fetchurl dockerTools generateImages makeWrapper sticker2;
   };
 in lib.mapAttrs (_: value: recurseIntoAttrs value) {
   de-ud-huge = stickerModel {

--- a/pkgs/sticker2_models/model.nix
+++ b/pkgs/sticker2_models/model.nix
@@ -8,6 +8,7 @@
 , fetchurl
 
 , dockerTools
+, generateImages
 , makeWrapper
 
 , sticker2
@@ -60,6 +61,14 @@ rec {
       platforms = platforms.unix;
     };
   };
+
+  vmImages = generateImages (import ../../nixos/vm-configuration.nix {
+    runCommand = ''
+      ${sticker2}/bin/sticker2 server \
+        --addr 0.0.0.0:4000 \
+        "${model}/share/sticker2/models/${modelName}/sticker.conf"
+    '';
+  });
 
   wrapper = stdenvNoCC.mkDerivation rec {
     inherit version;

--- a/pkgs/sticker_models/default.nix
+++ b/pkgs/sticker_models/default.nix
@@ -1,8 +1,8 @@
-{ lib, recurseIntoAttrs, stdenvNoCC, fetchurl, dockerTools, makeWrapper, sticker }:
+{ lib, recurseIntoAttrs, stdenvNoCC, fetchurl, dockerTools, generateImages, makeWrapper, sticker }:
 
 let
   stickerModel = import ./model.nix {
-    inherit lib stdenvNoCC fetchurl dockerTools makeWrapper sticker;
+    inherit lib stdenvNoCC fetchurl dockerTools generateImages makeWrapper sticker;
   };
   # Embeddings fetcher, uses the sticker-models repository.
   fetchEmbeddings = { name, sha256 }: {

--- a/pkgs/sticker_models/model.nix
+++ b/pkgs/sticker_models/model.nix
@@ -8,6 +8,7 @@
 , fetchurl
 
 , dockerTools
+, generateImages
 , makeWrapper
 
 , sticker
@@ -76,6 +77,14 @@ rec {
       platforms = platforms.unix;
     };
   };
+
+  vmImages = generateImages (import ../../nixos/vm-configuration.nix {
+    runCommand = ''
+      ${sticker}/bin/sticker server \
+        --addr 0.0.0.0:4000 \
+        "${model}/share/sticker/models/${modelName}/sticker.conf"
+    '';
+  });
 
   wrapper = stdenvNoCC.mkDerivation rec {
     inherit version;


### PR DESCRIPTION
@Blubberli this is the VM generation stuff. No expectation that you review the Nix code, but maybe you'd like to check the VM configuration `vm-configuration.nix`.

Not sure yet if we want to merge this. I think it is nice as a proof of concept, but a big downside of VMs compared to container images is that they are running OpenSSH and other stuff that is more sensitive to security, and need regular updates.